### PR TITLE
Trim unnecessary arrays

### DIFF
--- a/src/SimulationMetaDataConfiguration.jl
+++ b/src/SimulationMetaDataConfiguration.jl
@@ -25,15 +25,10 @@ export SimulationMetaData
     ExportSingleVTKHDF::Bool                = true
     ExportGridCells::Bool                   = false
     OutputVariables::Vector{String}         = [
-        "ChunkID",
-        "Kernel",
-        "KernelGradient",
         "Density",
         "Pressure",
         "Velocity",
         "Acceleration",
-        "BoundaryBool",
-        "ID",
         "Type",
         "GroupMarker",
         "GhostPoints",


### PR DESCRIPTION
## Summary
- drop IDs, kernels, and chunk markers from preprocessing
- simplify threaded array allocation
- remove unused kernel output handling
- update default output variables

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test()'` *(fails: interrupt during precompilation)*

------
https://chatgpt.com/codex/tasks/task_b_686683c10948832dafb31f24f87bf54c