### PR TITLE
Refactor module includes and externalize Paraview script

### DIFF
--- a/src/AutoParaviewTemplate.py
+++ b/src/AutoParaviewTemplate.py
@@ -1,0 +1,88 @@
+# import regex library
+import re
+
+# state file generated using paraview version 5.12.0
+import paraview
+paraview.compatibility.major = 5
+paraview.compatibility.minor = 12
+
+# Directory containing the .vtkhdf files
+directory = "__SAVE_LOCATION__"
+
+# List all .vtkhdf files in the directory
+import os
+regex = r"__PY_REGEX__"  # Regular expression to match the .vtkhdf files
+file_list = [os.path.join(directory, f) for f in os.listdir(directory) if re.search(regex, f)]
+
+#### import the simple module from the paraview
+from paraview.simple import *
+#### disable automatic camera reset on 'Show'
+paraview.simple._DisableFirstRenderCameraReset()
+
+# ----------------------------------------------------------------
+# setup views used in the visualization
+# ----------------------------------------------------------------
+
+# get the material library
+materialLibrary1 = GetMaterialLibrary()
+
+# Create a new 'Render View'
+renderView1 = CreateView('RenderView')
+
+# init the 'Grid Axes 3D Actor' selected for 'AxesGrid'
+renderView1.AxesGrid.Visibility = 1
+
+# set dimensionality of rendered view
+renderView1.InteractionMode = "__VIEW_DIMENSION__"
+
+SetActiveView(None)
+
+# create new layout object 'Layout #1'
+layout1 = CreateLayout(name='Layout #1')
+layout1.AssignView(0, renderView1)
+
+# ----------------------------------------------------------------
+# restore active view
+SetActiveView(renderView1)
+# ----------------------------------------------------------------
+
+# ----------------------------------------------------------------
+# setup the data processing pipelines
+# ----------------------------------------------------------------
+
+# create a new 'VTKHDF Reader'
+Simulation_vtkhdf = VTKHDFReader(registrationName='__SIM_NAME__.vtkhdf*', FileName=file_list)
+
+Simulation_vtkhdf.PointArrayStatus = __OUTPUT_VARIABLES__
+
+# ----------------------------------------------------------------
+# setup the visualization in view 'renderView1'
+# ----------------------------------------------------------------
+
+# show data from Simulation_vtkhdf
+Simulation_vtkhdfDisplay = Show(Simulation_vtkhdf, renderView1, 'GeometryRepresentation')
+
+Simulation_vtkhdfDisplay.SetRepresentationType('__REPRESENTATION__')
+
+# To always load in at correct position
+Simulation_vtkhdfDisplay.Position = [0.0, 0.0, 0.0]
+
+# set scalar coloring
+ColorBy(Simulation_vtkhdfDisplay, ('POINTS', '__COLOR_VAR__'))
+
+# rescale color and/or opacity maps used to include current data range
+RescaleTransferFunctionToDataRange(GetColorTransferFunction('__COLOR_VAR__'),
+                                   Simulation_vtkhdfDisplay)
+RescaleTransferFunctionToDataRange(GetOpacityTransferFunction('__COLOR_VAR__'),
+                                   Simulation_vtkhdfDisplay)
+
+# show color bar/color legend
+Simulation_vtkhdfDisplay.SetScalarBarVisibility(renderView1, True)
+
+# ----------------------------------------------------------------
+# reset view to fit data bounds
+renderView1.ResetCamera()
+# ----------------------------------------------------------------
+
+# Update the view to ensure updated data information
+renderView1.Update()

--- a/src/AutoParaviewTemplate.py
+++ b/src/AutoParaviewTemplate.py
@@ -71,10 +71,7 @@ Simulation_vtkhdfDisplay.Position = [0.0, 0.0, 0.0]
 ColorBy(Simulation_vtkhdfDisplay, ('POINTS', '__COLOR_VAR__'))
 
 # rescale color and/or opacity maps used to include current data range
-RescaleTransferFunctionToDataRange(GetColorTransferFunction('__COLOR_VAR__'),
-                                   Simulation_vtkhdfDisplay)
-RescaleTransferFunctionToDataRange(GetOpacityTransferFunction('__COLOR_VAR__'),
-                                   Simulation_vtkhdfDisplay)
+Simulation_vtkhdfDisplay.RescaleTransferFunctionToDataRange(True, False)
 
 # show color bar/color legend
 Simulation_vtkhdfDisplay.SetScalarBarVisibility(renderView1, True)

--- a/src/AuxiliaryFunctions.jl
+++ b/src/AuxiliaryFunctions.jl
@@ -44,9 +44,10 @@ function CloseHDFVTKManually(directory_path::String)
     vtkhdf_files = filter(file -> endswith(file, ".vtkhdf"), all_files)
 
     @threads for file_path in vtkhdf_files
-        file = h5open(file_path, "r")
         try
-            close(file)
+            h5open(file_path, "r") do _
+                nothing
+            end
         catch e
             @warn(e)
         end

--- a/src/OpenExternalPrograms.jl
+++ b/src/OpenExternalPrograms.jl
@@ -79,99 +79,20 @@ function AutoOpenParaview(SimMetaData::SimulationMetaData, OutputVariableNames;
     ExtractDimensionalityMetaData(::SimulationMetaData{N, FloatType}) where {N, FloatType} = N
     ViewDimension = ExtractDimensionalityMetaData(SimMetaData) == 2 ? "2D" : "3D"
 
-    ParaViewStateFile     = open(ParaViewStateFileName, "w")
-
-    ParaViewConfig    = 
-                            """
-                            # import regex library
-                            import re
-
-                            # state file generated using paraview version 5.12.0
-                            import paraview
-                            paraview.compatibility.major = 5
-                            paraview.compatibility.minor = 12
-                            
-                            # Directory containing the .vtkhdf files
-                            directory = "$(SimMetaData.SaveLocation)"
-
-                            # List all .vtkhdf files in the directory
-                            import os
-                            regex = r"$(py_regex)" # Regular expression to match the .vtkhdf files
-                            file_list = [os.path.join(directory, f) for f in os.listdir(directory) if re.search(regex,f)]
-
-                            #### import the simple module from the paraview
-                            from paraview.simple import *
-                            #### disable automatic camera reset on 'Show'
-                            paraview.simple._DisableFirstRenderCameraReset()
-                            
-                            # ----------------------------------------------------------------
-                            # setup views used in the visualization
-                            # ----------------------------------------------------------------
-
-                            # get the material library
-                            materialLibrary1 = GetMaterialLibrary()
-
-                            # Create a new 'Render View'
-                            renderView1 = CreateView('RenderView')
-                            
-                            # init the 'Grid Axes 3D Actor' selected for 'AxesGrid'
-                            renderView1.AxesGrid.Visibility = 1
-
-                            # set dimensionality of rendered view
-                            renderView1.InteractionMode = "$(ViewDimension)"
-                            
-                            SetActiveView(None)
-
-                            # create new layout object 'Layout #1'
-                            layout1 = CreateLayout(name='Layout #1')
-                            layout1.AssignView(0, renderView1)
-                            #layout1.SetSize(2252, 794)
-                            
-                            # ----------------------------------------------------------------
-                            # restore active view
-                            SetActiveView(renderView1)
-                            # ----------------------------------------------------------------
-
-                            # ----------------------------------------------------------------
-                            # setup the data processing pipelines
-                            # ----------------------------------------------------------------
-
-                            # create a new 'VTKHDF Reader'
-                            
-                            Simulation_vtkhdf = VTKHDFReader(registrationName='$(SimMetaData.SimulationName).vtkhdf*', FileName=file_list)
-
-                            Simulation_vtkhdf.PointArrayStatus = $("['" * join(OutputVariableNames, "', '") * "']")
-                            
-                            # ----------------------------------------------------------------
-                            # setup the visualization in view 'renderView1'
-                            # ----------------------------------------------------------------
-
-                            # show data from Simulation_vtkhdf
-                            Simulation_vtkhdfDisplay = Show(Simulation_vtkhdf, renderView1, 'GeometryRepresentation')
-
-                            Simulation_vtkhdfDisplay.SetRepresentationType('$(representation)')
-
-                            # To always load in at correct position
-                            Simulation_vtkhdfDisplay.Position = [0.0, 0.0, 0.0]
-
-                            # set scalar coloring
-                            ColorBy(Simulation_vtkhdfDisplay, ('POINTS', '$(color_variable)'))
-
-                            # rescale color and/or opacity maps used to include current data range
-                            Simulation_vtkhdfDisplay.RescaleTransferFunctionToDataRange(True, False)
-
-                            # show color bar/color legend
-                            Simulation_vtkhdfDisplay.SetScalarBarVisibility(renderView1, True)
-                            
-                            # Focus the camera on the dataset
-                            renderView1.ResetCamera()
-
-                            Render()
-                            """
-
-    write(ParaViewStateFile, ParaViewConfig) 
-
-    close(ParaViewStateFile)
+    template_path = joinpath(@__DIR__, "AutoParaviewTemplate.py")
+    template = read(template_path, String)
+    script = replace(template,
+                     "__SAVE_LOCATION__" => SimMetaData.SaveLocation,
+                     "__PY_REGEX__" => py_regex,
+                     "__SIM_NAME__" => SimMetaData.SimulationName,
+                     "__OUTPUT_VARIABLES__" => "['" * join(OutputVariableNames, "', '") * "']",
+                     "__REPRESENTATION__" => representation,
+                     "__COLOR_VAR__" => color_variable,
+                     "__VIEW_DIMENSION__" => ViewDimension,
+                     )
+    open(ParaViewStateFileName, "w") do io
+        write(io, script)
+    end
 
     if SimMetaData.VisualizeInParaview && paraview_cmd !== nothing
         try

--- a/src/SPHExample.jl
+++ b/src/SPHExample.jl
@@ -1,19 +1,23 @@
 module SPHExample
 
-    include("AuxiliaryFunctions.jl");
-    include("SPHKernels.jl")
-    include("SPHViscosityModels.jl")      
-    include("ProduceHDFVTK.jl")    
-    include("TimeStepping.jl");       
-    include("SimulationEquations.jl");
-    include("SimulationGeometry.jl")
-    include("SimulationMetaDataConfiguration.jl");
-    include("SimulationConstantsConfiguration.jl");
-    include("SimulationLoggerConfiguration.jl");
-    include("PreProcess.jl");
-    include("OpenExternalPrograms.jl")
-    include("SPHDensityDiffusionModels.jl")  
-    include("SPHCellList.jl") #Must be last    
+    # Include submodules in dependency order
+    submodules = [
+        "AuxiliaryFunctions.jl",
+        "SPHKernels.jl",
+        "SPHViscosityModels.jl",
+        "ProduceHDFVTK.jl",
+        "TimeStepping.jl",
+        "SimulationEquations.jl",
+        "SimulationGeometry.jl",
+        "SimulationMetaDataConfiguration.jl",
+        "SimulationConstantsConfiguration.jl",
+        "SimulationLoggerConfiguration.jl",
+        "PreProcess.jl",
+        "OpenExternalPrograms.jl",
+        "SPHDensityDiffusionModels.jl",
+        "SPHCellList.jl",
+    ]
+    foreach(include, submodules)
 
     # Re-export desired functions from each submodule
     using .AuxiliaryFunctions


### PR DESCRIPTION
## Summary
- streamline SPHExample module setup by iterating over an ordered list of submodules
- ensure HDF5 files close reliably with a `do` block in `CloseHDFVTKManually`
- move the long ParaView Python script to an external template and load it at runtime

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test()'` *(precompilation was interrupted, no tests executed)*

------
https://chatgpt.com/codex/tasks/task_b_68adb7b4fcd8832db8e5c13c1eb6f6b5