### PR TITLE
Fix CSV row count in pre-processing

### DIFF
--- a/src/PreProcess.jl
+++ b/src/PreProcess.jl
@@ -11,16 +11,17 @@ using ..SimulationGeometry
 function LoadSpecificCSV(::Val{D}, ::Type{T}, particle_type::ParticleType,
                          particle_group_marker::Int,
                          specific_csv::String) where {D, T}
-    nrows = countlines(specific_csv) - 1
+    file  = CSV.File(specific_csv)
+    nrows = length(file)
 
-    points       = Vector{SVector{D,T}}(undef, nrows)
+    points       = Vector{SVector{D, T}}(undef, nrows)
     density      = Vector{T}(undef, nrows)
     types        = Vector{ParticleType}(undef, nrows)
     group_marker = Vector{Int}(undef, nrows)
     idp          = Vector{Int}(undef, nrows)
 
     i = 1
-    for row ∈ CSV.File(specific_csv)
+    for row ∈ file
         P1   = row[Symbol("Points:0")]
         P2   = row[Symbol("Points:1")]
         P3   = row[Symbol("Points:2")]


### PR DESCRIPTION
## Summary
- Fix CSV loading to count actual rows, preventing uninitialized particles
- MovingSquare example no longer raises Int8 conversion errors

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test()'`
- `julia --project=. example/MovingSquare2d.jl` *(terminated early after verifying startup without errors)*

------
https://chatgpt.com/codex/tasks/task_b_68b15491ba64832d9b55f798e61262c0