### PR TITLE
Improve struct display

### DIFF
--- a/src/CustomPrettyPrinting.jl
+++ b/src/CustomPrettyPrinting.jl
@@ -1,0 +1,48 @@
+module CustomPrettyPrinting
+
+using TimerOutputs
+using ProgressMeter
+import Base: show
+
+using ..SimulationConstantsConfiguration: SimulationConstants
+using ..SimulationMetaDataConfiguration: SimulationMetaData
+using ..SPHKernels: SPHKernelInstance
+
+"""Return a concise representation of a value for pretty printing."""
+_val_repr(val) = string(val)
+_val_repr(val::AbstractString) = string('"', val, '"')
+_val_repr(val::AbstractArray) = string("Array{", eltype(val), "}(", size(val), ")")
+_val_repr(::TimerOutput) = ""
+_val_repr(::ProgressMeter.AbstractProgress) = ""
+
+function show(io::IO, sc::SimulationConstants{T}) where {T}
+    println(io, "SimulationConstants{$T}")
+    for field in fieldnames(typeof(sc))
+        val = getfield(sc, field)
+        repr = _val_repr(val)
+        suffix = isempty(repr) ? "" : " $(repr)"
+        println(io, "  $(field): $(typeof(val))$(suffix)")
+    end
+end
+
+function show(io::IO, meta::SimulationMetaData{D, T}) where {D, T}
+    println(io, "SimulationMetaData{$D, $T}")
+    for field in fieldnames(typeof(meta))
+        val = getfield(meta, field)
+        repr = _val_repr(val)
+        suffix = isempty(repr) ? "" : " $(repr)"
+        println(io, "  $(field): $(typeof(val))$(suffix)")
+    end
+end
+
+function show(io::IO, ker::SPHKernelInstance{K, D, T}) where {K, D, T}
+    println(io, "SPHKernelInstance{$K, $D, $T}")
+    for field in fieldnames(typeof(ker))
+        val = getfield(ker, field)
+        repr = _val_repr(val)
+        suffix = isempty(repr) ? "" : " $(repr)"
+        println(io, "  $(field): $(typeof(val))$(suffix)")
+    end
+end
+
+end # module

--- a/src/SPHExample.jl
+++ b/src/SPHExample.jl
@@ -16,6 +16,7 @@ module SPHExample
         "OpenExternalPrograms.jl",
         "SPHDensityDiffusionModels.jl",
         "SPHCellList.jl",
+        "CustomPrettyPrinting.jl",
     ]
     foreach(include, submodules)
 

--- a/src/SPHKernels.jl
+++ b/src/SPHKernels.jl
@@ -39,6 +39,21 @@ CubicSpline{T}() where {T} = CubicSpline{T}(one(T))
     η²::FloatType  = (0.01 * h)^2
 end
 
+import Base: show
+
+"""Return a string representation of ``val`` for pretty printing."""
+_val_repr(val) = string(val)
+
+function Base.show(io::IO, ker::SPHKernelInstance{K, D, T}) where {K, D, T}
+    println(io, "SPHKernelInstance{$K, $D, $T}")
+    for field in fieldnames(typeof(ker))
+        val = getfield(ker, field)
+        repr = _val_repr(val)
+        suffix = isempty(repr) ? "" : " $(repr)"
+        println(io, "  $(field): $(typeof(val))$(suffix)")
+    end
+end
+
 function SPHKernelInstance{D,T}(
     kernel::KernelType;
     dx::Union{T,Nothing}=nothing,

--- a/src/SPHKernels.jl
+++ b/src/SPHKernels.jl
@@ -39,21 +39,6 @@ CubicSpline{T}() where {T} = CubicSpline{T}(one(T))
     η²::FloatType  = (0.01 * h)^2
 end
 
-import Base: show
-
-"""Return a string representation of ``val`` for pretty printing."""
-_val_repr(val) = string(val)
-
-function Base.show(io::IO, ker::SPHKernelInstance{K, D, T}) where {K, D, T}
-    println(io, "SPHKernelInstance{$K, $D, $T}")
-    for field in fieldnames(typeof(ker))
-        val = getfield(ker, field)
-        repr = _val_repr(val)
-        suffix = isempty(repr) ? "" : " $(repr)"
-        println(io, "  $(field): $(typeof(val))$(suffix)")
-    end
-end
-
 function SPHKernelInstance{D,T}(
     kernel::KernelType;
     dx::Union{T,Nothing}=nothing,

--- a/src/SimulationConstantsConfiguration.jl
+++ b/src/SimulationConstantsConfiguration.jl
@@ -51,4 +51,22 @@ constants = SimulationConstants(ρ₀=1017, dx=0.03, α=0.02)
     SmagorinskyConstant::T     = 0.12
 end
 
+import Base: show
+
+"""Return a string representation of ``val`` without printing the full contents of
+large structures."""
+_val_repr(val) = string(val)
+
+_val_repr(val::AbstractString) = string('"', val, '"')
+
+function Base.show(io::IO, sc::SimulationConstants{T}) where {T}
+    println(io, "SimulationConstants{$T}")
+    for field in fieldnames(typeof(sc))
+        val = getfield(sc, field)
+        repr = _val_repr(val)
+        suffix = isempty(repr) ? "" : " $(repr)"
+        println(io, "  $(field): $(typeof(val))$(suffix)")
+    end
+end
+
 end

--- a/src/SimulationConstantsConfiguration.jl
+++ b/src/SimulationConstantsConfiguration.jl
@@ -50,23 +50,4 @@ constants = SimulationConstants(ρ₀=1017, dx=0.03, α=0.02)
     BlinConstant::T            = 0.0066
     SmagorinskyConstant::T     = 0.12
 end
-
-import Base: show
-
-"""Return a string representation of ``val`` without printing the full contents of
-large structures."""
-_val_repr(val) = string(val)
-
-_val_repr(val::AbstractString) = string('"', val, '"')
-
-function Base.show(io::IO, sc::SimulationConstants{T}) where {T}
-    println(io, "SimulationConstants{$T}")
-    for field in fieldnames(typeof(sc))
-        val = getfield(sc, field)
-        repr = _val_repr(val)
-        suffix = isempty(repr) ? "" : " $(repr)"
-        println(io, "  $(field): $(typeof(val))$(suffix)")
-    end
-end
-
 end

--- a/src/SimulationMetaDataConfiguration.jl
+++ b/src/SimulationMetaDataConfiguration.jl
@@ -48,4 +48,24 @@ export SimulationMetaData
     FlagMDBCSimple::Bool                    = false
 end
 
+import Base: show
+
+"""Return a concise representation of a value for pretty printing."""
+_val_repr(val) = string(val)
+
+_val_repr(val::AbstractString) = string('"', val, '"')
+_val_repr(val::AbstractArray) = string("Array{", eltype(val), "}(", size(val), ")")
+_val_repr(::TimerOutput) = ""
+_val_repr(::ProgressMeter.AbstractProgress) = ""
+
+function Base.show(io::IO, meta::SimulationMetaData{D, T}) where {D, T}
+    println(io, "SimulationMetaData{$D, $T}")
+    for field in fieldnames(typeof(meta))
+        val = getfield(meta, field)
+        repr = _val_repr(val)
+        suffix = isempty(repr) ? "" : " $(repr)"
+        println(io, "  $(field): $(typeof(val))$(suffix)")
+    end
+end
+
 end

--- a/src/SimulationMetaDataConfiguration.jl
+++ b/src/SimulationMetaDataConfiguration.jl
@@ -47,25 +47,4 @@ export SimulationMetaData
     ChunkMultiplier::Int                    = 1
     FlagMDBCSimple::Bool                    = false
 end
-
-import Base: show
-
-"""Return a concise representation of a value for pretty printing."""
-_val_repr(val) = string(val)
-
-_val_repr(val::AbstractString) = string('"', val, '"')
-_val_repr(val::AbstractArray) = string("Array{", eltype(val), "}(", size(val), ")")
-_val_repr(::TimerOutput) = ""
-_val_repr(::ProgressMeter.AbstractProgress) = ""
-
-function Base.show(io::IO, meta::SimulationMetaData{D, T}) where {D, T}
-    println(io, "SimulationMetaData{$D, $T}")
-    for field in fieldnames(typeof(meta))
-        val = getfield(meta, field)
-        repr = _val_repr(val)
-        suffix = isempty(repr) ? "" : " $(repr)"
-        println(io, "  $(field): $(typeof(val))$(suffix)")
-    end
-end
-
 end


### PR DESCRIPTION
## Summary
- add human-friendly show methods for `SimulationConstants`, `SimulationMetaData`, and `SPHKernelInstance`

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test()'`


------
https://chatgpt.com/codex/tasks/task_b_68b16894b0b4832d8eb55a9f7f60b034