### PR TITLE
Avoid tuple map in cell extraction

### DIFF
--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -55,13 +55,19 @@ using Bumper
         # We add 0.5 instead of 1, to ensure proper rounding behavior when restoring the sign for negative numbers.
         Int(sign(x)) * unsafe_trunc(Int, muladd(abs(x),InverseCutOff,0.5))
     end
-   
-    @inline function ExtractCells!(Particles, InverseCutOff)
-        @inbounds @simd ivdep for i ∈ eachindex(Particles.Cells)
-            # t = map(map_floor, Tuple(Particles.Position[i]))
-            t = CartesianIndex(map(x -> map_floor(x, InverseCutOff), Tuple(Particles.Position[i])))
-            Particles.Cells[i] = CartesianIndex(t)
+
+    @inline function extract_cells!(cells, position::Vector{SVector{D, T}}, inverse_cutoff) where {D, T}
+        @inbounds @simd ivdep for i ∈ eachindex(cells)
+            pos = position[i]
+            cells[i] = CartesianIndex(ntuple(j -> map_floor(@inbounds pos[j], inverse_cutoff),
+                                             Val(D)))
         end
+
+        return nothing
+    end
+
+    @inline function ExtractCells!(particles, inverse_cutoff)
+        extract_cells!(particles.Cells, particles.Position, inverse_cutoff)
 
         return nothing
     end


### PR DESCRIPTION
## Summary
- streamline ExtractCells! to iterate over particle coordinates directly instead of mapping over tuples
- parametrize cell extraction on static dimension to eliminate Val(length(pos))

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test()'`


------
https://chatgpt.com/codex/tasks/task_b_68b1a9d9e1c8832d92984a806b4de62b