### PR TITLE
Fix missing unicode plot in log file

### DIFF
--- a/src/SimulationLoggerConfiguration.jl
+++ b/src/SimulationLoggerConfiguration.jl
@@ -223,7 +223,6 @@ module SimulationLoggerConfiguration
             @info "\n Sorted by time \n"
             show(SimLogger.LoggerIo, HourGlass)
         end
-        close(SimLogger.LoggerIo)
     end
 
 end


### PR DESCRIPTION
## Summary
- keep log file open until after final time-step plot is written

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test()'` *(fails: Package SPHExample errored during testing)*

------
https://chatgpt.com/codex/tasks/task_b_68b21163f164832da90bca7ab622b2fa