### PR TITLE
Use type dispatch for particle shifting

### DIFF
--- a/example/Dambreak2dMDBC.jl
+++ b/example/Dambreak2dMDBC.jl
@@ -27,8 +27,8 @@ let
     # Load in particles
     SimParticles = AllocateDataStructures(SimulationGeometry)
 
-    SimMetaDataDambreak  = SimulationMetaData{Dimensions,FloatType}(
-        SimulationName="DamBreak2D", 
+    SimMetaDataDambreak  = SimulationMetaData{Dimensions,FloatType,ShiftingDisabled}(
+        SimulationName="DamBreak2D",
         SaveLocation="C:/TestSimulations/DamBreak2D_MDBC/",
         SimulationTime=2,
         OutputTimes=collect(0.01:0.01:2),

--- a/example/Dambreak3d.jl
+++ b/example/Dambreak3d.jl
@@ -33,7 +33,7 @@ let
     SimParticles = AllocateDataStructures(SimulationGeometry)
 
     # --- Simulation metadata & logging ---
-    SimMetaDataDambreak3D = SimulationMetaData{Dimensions,FloatType}(
+    SimMetaDataDambreak3D = SimulationMetaData{Dimensions,FloatType,ShiftingDisabled}(
         SimulationName         = "DamBreak3D_Test",
         SaveLocation           = "C:/TestSimulations/TESTING_CPU_3DDambreak",
         SimulationTime         = 1.6,

--- a/example/DucklingMDBC.jl
+++ b/example/DucklingMDBC.jl
@@ -26,7 +26,7 @@ let
     # Load in particles
     SimParticles = AllocateDataStructures(SimulationGeometry)
 
-    SimMetaDataWedge  = SimulationMetaData{Dimensions,FloatType}(
+    SimMetaDataWedge  = SimulationMetaData{Dimensions,FloatType,ShiftingDisabled}(
         SimulationName="CaseDuckling", 
         SaveLocation="E:/SecondApproach/TESTING_CPU_Duckling",
         SimulationTime=1,
@@ -37,7 +37,6 @@ let
         OpenLogFile=true,
         FlagOutputKernelValues=false,
         FlagLog=true,
-        FlagShifting=false,
         FlagMDBCSimple=true,
     )
 

--- a/example/MovingSquare2d.jl
+++ b/example/MovingSquare2d.jl
@@ -15,7 +15,7 @@ let
         CFL=0.2
     )
 
-    SimMetaDataMovingSquare  = SimulationMetaData{Dimensions,FloatType}(
+    SimMetaDataMovingSquare  = SimulationMetaData{Dimensions,FloatType,ShiftingEnabled}(
         SimulationName="MovingSquare2D", 
         SaveLocation="C:/TestSimulations/MovingSquare2D",
         SimulationTime=2.5,
@@ -25,7 +25,7 @@ let
         OpenLogFile=true,
         FlagOutputKernelValues=false,
         FlagLog=true,
-        FlagShifting=true
+        shifting_mode=ShiftingEnabled()
     )
     FixedBoundary = Geometry{Dimensions, FloatType}(
         CSVFile     = "./input/moving_square_2d/MovingSquare_Dp$(SimConstantsMovingSquare.dx)_Fixed.csv",

--- a/example/StillWedgeMDBC.jl
+++ b/example/StillWedgeMDBC.jl
@@ -27,7 +27,7 @@ let
     # Load in particles
     SimParticles = AllocateDataStructures(SimulationGeometry)
 
-    SimMetaDataWedge  = SimulationMetaData{Dimensions,FloatType}(
+    SimMetaDataWedge  = SimulationMetaData{Dimensions,FloatType,ShiftingDisabled}(
         SimulationName="StillWedge", 
         SaveLocation="C:/TestSimulations/StillWedge2D_MDBC",
         SimulationTime=4.0,

--- a/example/StillWedgeMiddleSquareMDBC.jl
+++ b/example/StillWedgeMiddleSquareMDBC.jl
@@ -27,7 +27,7 @@ let
     # Load in particles
     SimParticles = AllocateDataStructures(SimulationGeometry)
 
-    SimMetaDataWedge  = SimulationMetaData{Dimensions,FloatType}(
+    SimMetaDataWedge  = SimulationMetaData{Dimensions,FloatType,ShiftingDisabled}(
         SimulationName="StillWedge", 
         SaveLocation="E:/SecondApproach/StillWedgeMiddleSquare2D_MDBC",
         SimulationTime=4,

--- a/src/CustomPrettyPrinting.jl
+++ b/src/CustomPrettyPrinting.jl
@@ -25,8 +25,8 @@ function show(io::IO, sc::SimulationConstants{T}) where {T}
     end
 end
 
-function show(io::IO, meta::SimulationMetaData{D, T}) where {D, T}
-    println(io, "SimulationMetaData{$D, $T}")
+function show(io::IO, meta::SimulationMetaData{D, T, S}) where {D, T, S}
+    println(io, "SimulationMetaData{$D, $T, $S}")
     for field in fieldnames(typeof(meta))
         val = getfield(meta, field)
         repr = _val_repr(val)

--- a/src/OpenExternalPrograms.jl
+++ b/src/OpenExternalPrograms.jl
@@ -76,7 +76,7 @@ function AutoOpenParaview(SimMetaData::SimulationMetaData, OutputVariableNames;
         py_regex = "^$(SimMetaData.SimulationName)_(\\d+).vtk" #^ means to anchor the regex to the start of the string
     end
 
-    ExtractDimensionalityMetaData(::SimulationMetaData{N, FloatType}) where {N, FloatType} = N
+    ExtractDimensionalityMetaData(::SimulationMetaData{N, FloatType, S}) where {N, FloatType, S} = N
     ViewDimension = ExtractDimensionalityMetaData(SimMetaData) == 2 ? "2D" : "3D"
 
     template_path = joinpath(@__DIR__, "AutoParaviewTemplate.py")

--- a/src/PreProcess.jl
+++ b/src/PreProcess.jl
@@ -7,6 +7,7 @@ using StaticArrays
 using StructArrays
 
 using ..SimulationGeometry
+using ..SimulationMetaDataConfiguration: SimulationMetaData, ShiftingEnabled, ShiftingDisabled
 
 function LoadSpecificCSV(::Val{D}, ::Type{T}, particle_type::ParticleType,
                          particle_group_marker::Int,
@@ -137,9 +138,9 @@ function AllocateSupportDataStructures(Position)
     return dρdtI, Velocityₙ⁺, Positionₙ⁺, ρₙ⁺, ∇Cᵢ, ∇◌rᵢ
 end
 
-function AllocateThreadedArrays(SimMetaData, SimParticles, dρdtI, ∇Cᵢ, ∇◌rᵢ   ; n_copy = Base.Threads.nthreads())
-    
-        
+function AllocateThreadedArrays(SimMetaData::SimulationMetaData{D,F,ShiftingDisabled},
+                                SimParticles, dρdtI, ∇Cᵢ, ∇◌rᵢ;
+                                n_copy = Base.Threads.nthreads()) where {D,F}
     dρdtIThreaded        = [copy(dρdtI) for _ in 1:n_copy]
     AccelerationThreaded = [copy(SimParticles.KernelGradient) for _ in 1:n_copy]
 
@@ -157,18 +158,37 @@ function AllocateThreadedArrays(SimMetaData, SimParticles, dρdtI, ∇Cᵢ, ∇�
         ))
     end
 
-    if SimMetaData.FlagShifting
-        ∇CᵢThreaded  = [copy(∇Cᵢ) for _ in 1:n_copy]
-        ∇◌rᵢThreaded = [copy(∇◌rᵢ) for _ in 1:n_copy]
+    return StructArray(nt)
+end
+
+function AllocateThreadedArrays(SimMetaData::SimulationMetaData{D,F,ShiftingEnabled},
+                                SimParticles, dρdtI, ∇Cᵢ, ∇◌rᵢ;
+                                n_copy = Base.Threads.nthreads()) where {D,F}
+    dρdtIThreaded        = [copy(dρdtI) for _ in 1:n_copy]
+    AccelerationThreaded = [copy(SimParticles.KernelGradient) for _ in 1:n_copy]
+
+    nt = (
+        dρdtIThreaded = dρdtIThreaded,
+        AccelerationThreaded = AccelerationThreaded,
+    )
+
+    if SimMetaData.FlagOutputKernelValues
+        KernelThreaded         = [copy(SimParticles.Kernel) for _ in 1:n_copy]
+        KernelGradientThreaded = [copy(SimParticles.KernelGradient) for _ in 1:n_copy]
         nt = merge(nt, (
-            ∇CᵢThreaded  = ∇CᵢThreaded,
-            ∇◌rᵢThreaded = ∇◌rᵢThreaded,
+            KernelThreaded = KernelThreaded,
+            KernelGradientThreaded = KernelGradientThreaded,
         ))
     end
 
-    SimThreadedArrays = StructArray(nt)
+    ∇CᵢThreaded  = [copy(∇Cᵢ) for _ in 1:n_copy]
+    ∇◌rᵢThreaded = [copy(∇◌rᵢ) for _ in 1:n_copy]
+    nt = merge(nt, (
+        ∇CᵢThreaded  = ∇CᵢThreaded,
+        ∇◌rᵢThreaded = ∇◌rᵢThreaded,
+    ))
 
-    return SimThreadedArrays
+    return StructArray(nt)
 end
 
 function LoadBoundaryNormals(::Val{D}, ::Type{T}, path_mdbc) where {D, T}

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -160,10 +160,10 @@ using Bumper
 
     f(SimKernel, GhostPoint) = CartesianIndex(map(x->map_floor(x,SimKernel.H⁻¹), Tuple(GhostPoint)))
     function NeighborLoopMDBC!(SimKernel,
-                               SimMetaData::SimulationMetaData{Dimensions, _},
+                               SimMetaData::SimulationMetaData{Dimensions, FloatType, S},
                                SimConstants, ParticleRanges, CellDict, Position,
                                Density, GhostPoints, GhostNormals, ParticleType,
-                               bᵧ, Aᵧ) where {Dimensions, _}
+                               bᵧ, Aᵧ) where {Dimensions, FloatType, S}
         
         FullStencil = CartesianIndices(ntuple(_->-1:1, Dimensions))
 
@@ -177,8 +177,8 @@ using Bumper
             
                 # compute and accumulate into the locals
                 GhostCellIndex = f(SimKernel, GhostPoints[iter])
-                @inbounds for S ∈ FullStencil
-                    SCellIndex = GhostCellIndex + S
+                @inbounds for St ∈ FullStencil
+                    SCellIndex = GhostCellIndex + St
 
                     # Returns a range, x>:x for exact match and x=:x for no match
                     # utilizes that it is a sorted array and requires no isequal constructor,
@@ -260,24 +260,14 @@ using Bumper
                 SimThreadedArrays.KernelGradientThreaded[ichunk][j] += -∇ᵢWᵢⱼ
             end
 
-            if SimMetaData.FlagShifting
-                
-                MLcond = MotionLimiter[i] * MotionLimiter[j]
-
-                SimThreadedArrays.∇CᵢThreaded[ichunk][i]   += (m₀/ρᵢ) *  ∇ᵢWᵢⱼ
-                SimThreadedArrays.∇CᵢThreaded[ichunk][j]   += (m₀/ρⱼ) * -∇ᵢWᵢⱼ
-        
-                # Switch signs compared to DSPH, else free surface detection does not make sense
-                # Agrees, https://arxiv.org/abs/2110.10076, it should have been r_ji
-                SimThreadedArrays.∇◌rᵢThreaded[ichunk][i]  += (m₀/ρⱼ) * dot(-xᵢⱼ , ∇ᵢWᵢⱼ)  * MLcond
-                SimThreadedArrays.∇◌rᵢThreaded[ichunk][j]  += (m₀/ρᵢ) * dot( xᵢⱼ ,-∇ᵢWᵢⱼ)  * MLcond
-            end
+            shifting_contributions!(SimMetaData.shifting_mode, SimThreadedArrays,
+                                      ichunk, i, j, m₀, ρᵢ, ρⱼ, ∇ᵢWᵢⱼ, xᵢⱼ, MotionLimiter)
         end
 
         return nothing
     end
 
-    Base.@propagate_inbounds function ComputeInteractionsMDBC!(SimKernel, SimMetaData::SimulationMetaData{Dimensions, FloatType}, SimConstants, Position, Density, ParticleType, GhostPoints, i, j) where {Dimensions, FloatType}
+    Base.@propagate_inbounds function ComputeInteractionsMDBC!(SimKernel, SimMetaData::SimulationMetaData{Dimensions, FloatType, S}, SimConstants, Position, Density, ParticleType, GhostPoints, i, j) where {Dimensions, FloatType, S}
         (; ρ₀, m₀, α, γ, g, c₀, δᵩ, Cb, Cb⁻¹, ν₀, dx, SmagorinskyConstant, BlinConstant) = SimConstants
 
         (; h⁻¹, h, η², H², αD) = SimKernel
@@ -341,6 +331,36 @@ using Bumper
         end
     end
 
+    @inline zero_shifting!(::ShiftingDisabled, ∇Cᵢ, ∇◌rᵢ) = nothing
+    @inline zero_shifting!(::ShiftingEnabled, ∇Cᵢ, ∇◌rᵢ) = @threads for arr in (∇Cᵢ, ∇◌rᵢ)
+        fill!(arr, zero(eltype(arr)))
+    end
+
+    @inline reduce_shifting!(::ShiftingDisabled, SimThreadedArrays, ∇Cᵢ, ∇◌rᵢ) = nothing
+    @inline reduce_shifting!(::ShiftingEnabled, SimThreadedArrays, ∇Cᵢ, ∇◌rᵢ) = begin
+        reduce_sum!(∇Cᵢ, SimThreadedArrays.∇CᵢThreaded)
+        reduce_sum!(∇◌rᵢ, SimThreadedArrays.∇◌rᵢThreaded)
+    end
+
+    @inline shifting_contributions!(::ShiftingDisabled, args...) = nothing
+    @inline function shifting_contributions!(::ShiftingEnabled, SimThreadedArrays, ichunk, i, j, m₀, ρᵢ, ρⱼ, ∇ᵢWᵢⱼ, xᵢⱼ, MotionLimiter)
+        MLcond = MotionLimiter[i] * MotionLimiter[j]
+
+        SimThreadedArrays.∇CᵢThreaded[ichunk][i]   += (m₀/ρᵢ) *  ∇ᵢWᵢⱼ
+        SimThreadedArrays.∇CᵢThreaded[ichunk][j]   += (m₀/ρⱼ) * -∇ᵢWᵢⱼ
+
+        # Switch signs compared to DSPH, else free surface detection does not make sense
+        # Agrees, https://arxiv.org/abs/2110.10076, it should have been r_ji
+        SimThreadedArrays.∇◌rᵢThreaded[ichunk][i]  += (m₀/ρⱼ) * dot(-xᵢⱼ , ∇ᵢWᵢⱼ)  * MLcond
+        SimThreadedArrays.∇◌rᵢThreaded[ichunk][j]  += (m₀/ρᵢ) * dot( xᵢⱼ ,-∇ᵢWᵢⱼ)  * MLcond
+    end
+
+    @inline maybe_resize_shifting_arrays!(::ShiftingEnabled, ∇Cᵢ, ∇◌rᵢ) = nothing
+    @inline maybe_resize_shifting_arrays!(::ShiftingDisabled, ∇Cᵢ, ∇◌rᵢ) = begin
+        resize!(∇Cᵢ , 0)
+        resize!(∇◌rᵢ, 0)
+    end
+
     function ResetStep!(SimMetaData, SimThreadedArrays, dρdtI, Acceleration, Kernel, KernelGradient, ∇Cᵢ, ∇◌rᵢ)
         # Threaded zeroing for main arrays
         @threads for arr in (dρdtI, Acceleration)
@@ -353,11 +373,7 @@ using Bumper
             end
         end
 
-        if SimMetaData.FlagShifting
-            @threads for arr in (∇Cᵢ, ∇◌rᵢ)
-                fill!(arr, zero(eltype(arr)))
-            end
-        end
+        zero_shifting!(SimMetaData.shifting_mode, ∇Cᵢ, ∇◌rᵢ)
 
         # Threaded zeroing for fields in SimThreadedArrays
         foreachfield(f -> begin
@@ -372,17 +388,14 @@ using Bumper
     function ReductionStep!(SimMetaData, SimThreadedArrays, dρdtI, Acceleration, Kernel, KernelGradient, ∇Cᵢ, ∇◌rᵢ)
         reduce_sum!(dρdtI, SimThreadedArrays.dρdtIThreaded)
         reduce_sum!(Acceleration, SimThreadedArrays.AccelerationThreaded)
-  
+
         if SimMetaData.FlagOutputKernelValues
             reduce_sum!(Kernel, SimThreadedArrays.KernelThreaded)
             reduce_sum!(KernelGradient, SimThreadedArrays.KernelGradientThreaded)
         end
 
-        if SimMetaData.FlagShifting
-            reduce_sum!(∇Cᵢ, SimThreadedArrays.∇CᵢThreaded)
-            reduce_sum!(∇◌rᵢ, SimThreadedArrays.∇◌rᵢThreaded)
-        end
-    
+        reduce_shifting!(SimMetaData.shifting_mode, SimThreadedArrays, ∇Cᵢ, ∇◌rᵢ)
+
         return nothing
     end
     
@@ -436,7 +449,7 @@ using Bumper
         end
     end
     
-    function HalfTimeStep(::SimulationMetaData{Dimensions, FloatType}, SimConstants, SimParticles, Positionₙ⁺, Velocityₙ⁺, ρₙ⁺, dρdtI, dt₂) where {Dimensions, FloatType}
+    function HalfTimeStep(::SimulationMetaData{Dimensions, FloatType, S}, SimConstants, SimParticles, Positionₙ⁺, Velocityₙ⁺, ρₙ⁺, dρdtI, dt₂) where {Dimensions, FloatType, S}
         (; Position, Density, Velocity, Acceleration, GravityFactor, MotionLimiter) = SimParticles
 
         @inbounds @simd ivdep for i in eachindex(Position)
@@ -450,34 +463,32 @@ using Bumper
         return nothing
     end
 
-    function FullTimeStep(SimMetaData, SimKernel, SimConstants, SimParticles, ∇Cᵢ, ∇◌rᵢ, dt)
+    function FullTimeStep(SimMetaData::SimulationMetaData{D,F,ShiftingDisabled},
+                          SimKernel, SimConstants, SimParticles, ∇Cᵢ, ∇◌rᵢ, dt) where {D,F}
         (; Position, Velocity, Acceleration, GravityFactor, MotionLimiter) = SimParticles
-  
-        if !SimMetaData.FlagShifting
-            @inbounds @simd ivdep for i in eachindex(Position)
-                Acceleration[i]   +=  ConstructGravitySVector(Acceleration[i], SimConstants.g * GravityFactor[i])
-                Velocity[i]       +=  Acceleration[i] * dt * MotionLimiter[i]
-                Position[i]       +=  (((Velocity[i] + (Velocity[i] - Acceleration[i] * dt * MotionLimiter[i])) / 2) * dt) * MotionLimiter[i]
-            end
-        else
-            A     = 2# Value between 1 to 6 advised
-            A_FST = 0; # zero for internal flows
-            A_FSM = length(first(Position)); #2d, 3d val different
-            @inbounds @simd ivdep for i in eachindex(Position)
-                Acceleration[i]   +=  ConstructGravitySVector(Acceleration[i], SimConstants.g * GravityFactor[i])
-                Velocity[i]       +=  Acceleration[i] * dt * MotionLimiter[i]
-        
-                A_FSC                  = (∇◌rᵢ[i] - A_FST)/(A_FSM - A_FST)
-                if A_FSC < 0
-                    δxᵢ = zero(eltype(Position))
-                else
-                    δxᵢ = -A_FSC * A * SimKernel.h * norm(Velocity[i]) * dt * ∇Cᵢ[i]
-                end
-        
-                Position[i]           += (((Velocity[i] + (Velocity[i] - Acceleration[i] * dt * MotionLimiter[i])) / 2) * dt + δxᵢ) * MotionLimiter[i]
-            end
+        @inbounds @simd ivdep for i in eachindex(Position)
+            Acceleration[i]   +=  ConstructGravitySVector(Acceleration[i], SimConstants.g * GravityFactor[i])
+            Velocity[i]       +=  Acceleration[i] * dt * MotionLimiter[i]
+            Position[i]       +=  (((Velocity[i] + (Velocity[i] - Acceleration[i] * dt * MotionLimiter[i])) / 2) * dt) * MotionLimiter[i]
         end
+        return nothing
+    end
 
+    function FullTimeStep(SimMetaData::SimulationMetaData{D,F,ShiftingEnabled},
+                          SimKernel, SimConstants, SimParticles, ∇Cᵢ, ∇◌rᵢ, dt) where {D,F}
+        (; Position, Velocity, Acceleration, GravityFactor, MotionLimiter) = SimParticles
+        A     = 2 # Value between 1 to 6 advised
+        A_FST = 0 # zero for internal flows
+        A_FSM = length(first(Position)) # 2d, 3d val different
+        @inbounds @simd ivdep for i in eachindex(Position)
+            Acceleration[i]   +=  ConstructGravitySVector(Acceleration[i], SimConstants.g * GravityFactor[i])
+            Velocity[i]       +=  Acceleration[i] * dt * MotionLimiter[i]
+
+            A_FSC = (∇◌rᵢ[i] - A_FST) / (A_FSM - A_FST)
+            δxᵢ = A_FSC < 0 ? zero(eltype(Position)) : -A_FSC * A * SimKernel.h * norm(Velocity[i]) * dt * ∇Cᵢ[i]
+
+            Position[i] += (((Velocity[i] + (Velocity[i] - Acceleration[i] * dt * MotionLimiter[i])) / 2) * dt + δxᵢ) * MotionLimiter[i]
+        end
         return nothing
     end
 
@@ -530,12 +541,12 @@ using Bumper
 
     
     @inbounds function SimulationLoop(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
-                                      SimMetaData::SimulationMetaData{Dimensions, FloatType},
+                                      SimMetaData::SimulationMetaData{Dimensions, FloatType, S},
                                       SimConstants, SimParticles, Stencil,
                                       ParticleRanges, UniqueCells, CellDict,
                                       SortingScratchSpace, SimThreadedArrays,
                                       dρdtI, Velocityₙ⁺, Positionₙ⁺, ρₙ⁺,
-                                      ∇Cᵢ, ∇◌rᵢ, MotionDefinition) where {Dimensions, FloatType, SDD<:SPHDensityDiffusion, SV<:SPHViscosity}
+                                      ∇Cᵢ, ∇◌rᵢ, MotionDefinition) where {Dimensions, FloatType, S, SDD<:SPHDensityDiffusion, SV<:SPHViscosity}
         Position       = SimParticles.Position
         Density        = SimParticles.Density
         Pressure       = SimParticles.Pressure
@@ -630,7 +641,7 @@ using Bumper
     
     ###===
     function RunSimulation(;SimGeometry::Vector{Geometry{Dimensions, FloatType}}, #Don't further specify type for now
-        SimMetaData::SimulationMetaData{Dimensions, FloatType},
+        SimMetaData::SimulationMetaData{Dimensions, FloatType, S},
         SimConstants::SimulationConstants,
         SimKernel::SPHKernelInstance,
         SimLogger::SimulationLogger,
@@ -638,7 +649,7 @@ using Bumper
         SimViscosity::SV,
         SimDensityDiffusion::SDD,
         ParticleNormalsPath::Union{Nothing,String} = nothing
-        ) where {Dimensions,FloatType,SV<:SPHViscosity,SDD<:SPHDensityDiffusion}
+        ) where {Dimensions,FloatType,S,SV<:SPHViscosity,SDD<:SPHDensityDiffusion}
 
         # Unpack the relevant simulation meta data
         (; HourGlass) = SimMetaData;
@@ -662,10 +673,7 @@ using Bumper
             end
         # end
 
-        if !SimMetaData.FlagShifting
-            resize!(∇Cᵢ , 0)
-            resize!(∇◌rᵢ, 0)
-        end
+        maybe_resize_shifting_arrays!(SimMetaData.shifting_mode, ∇Cᵢ, ∇◌rᵢ)
 
         if SimMetaData.FlagLog
             InitializeLogger(SimLogger, SimConstants, SimMetaData, SimKernel, SimViscosity, SimDensityDiffusion, SimGeometry, SimParticles)

--- a/src/SPHExample.jl
+++ b/src/SPHExample.jl
@@ -52,7 +52,7 @@ module SPHExample
     export SimulationLogger, generate_format_string, InitializeLogger, LogSimulationDetails, LogStep, LogFinal
 
     using .SimulationMetaDataConfiguration
-    export SimulationMetaData
+    export SimulationMetaData, ShiftingEnabled, ShiftingDisabled
 
     using .SimulationConstantsConfiguration
     export SimulationConstants

--- a/src/SimulationMetaDataConfiguration.jl
+++ b/src/SimulationMetaDataConfiguration.jl
@@ -4,10 +4,14 @@ using TimerOutputs
 using ProgressMeter
 using Base: @kwdef
 
-export SimulationMetaData
+abstract type ShiftingMode end
+struct ShiftingEnabled  <: ShiftingMode end
+struct ShiftingDisabled <: ShiftingMode end
+
+export SimulationMetaData, ShiftingEnabled, ShiftingDisabled
 
 
-@kwdef mutable struct SimulationMetaData{Dimensions, FloatType <: AbstractFloat}
+@kwdef mutable struct SimulationMetaData{Dimensions, FloatType <: AbstractFloat, S<:ShiftingMode}
     SimulationName::String
     SaveLocation::String
     HourGlass::TimerOutput                  = TimerOutput()
@@ -42,7 +46,7 @@ export SimulationMetaData
     OpenLogFile::Bool                       = true
     FlagOutputKernelValues::Bool            = false
     FlagLog::Bool                           = false
-    FlagShifting::Bool                      = false
+    shifting_mode::S                        = ShiftingDisabled()
     FlagSingleStepTimeStepping::Bool        = false
     ChunkMultiplier::Int                    = 1
     FlagMDBCSimple::Bool                    = false

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,7 +20,7 @@ end
     T = Float64
     sc = SimulationConstants{T}()
     ker = SPHKernelInstance{D,T}(WendlandC2(); dx=sc.dx)
-    meta = SimulationMetaData{D,T}(SimulationName="iso", SaveLocation=".")
+    meta = SimulationMetaData{D,T,ShiftingDisabled}(SimulationName="iso", SaveLocation=".")
 
     pos = [SVector{D,T}(0, 0)]
     vel = [SVector{D,T}(0, 0)]


### PR DESCRIPTION
## Summary
- encode particle shifting via `ShiftingMode` types in `SimulationMetaData`
- dispatch threaded array allocation and updates on `ShiftingMode`
- split `FullTimeStep` for shifting and non-shifting cases

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test()'`

------
https://chatgpt.com/codex/tasks/task_b_68b34aabafd8832d9d24febca5f73d58