### PR TITLE
Reorder loops for cache-friendly accumulation

### DIFF
--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -329,11 +329,10 @@ using Bumper
         n = length(target_array)
         num_threads = nthreads()
         chunk_size = ceil(Int, n / num_threads)
-        @inbounds @threads for t in 1:num_threads
-            local start_idx = 1 + (t-1) * chunk_size
-            local end_idx = min(t * chunk_size, n)
-            for j in eachindex(arrays)
-                local array = arrays[j]  # Access array only once per thread
+        for array in arrays
+            @inbounds @threads for t in 1:num_threads
+                local start_idx = 1 + (t - 1) * chunk_size
+                local end_idx = min(t * chunk_size, n)
                 @simd ivdep for i in start_idx:end_idx
                     @inbounds target_array[i] += array[i]
                 end


### PR DESCRIPTION
## Summary
- Loop over arrays in `reduce_sum!` before parallelizing indices for better cache reuse

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test()'`


------
https://chatgpt.com/codex/tasks/task_b_68b4ca6959e0832d9fd3f6aa379aae87