### PR TITLE
Use conditionals in cubic spline kernel

### DIFF
--- a/src/SPHKernels.jl
+++ b/src/SPHKernels.jl
@@ -88,7 +88,13 @@ end
 
 @inline function Wᵢⱼ(kernel::SPHKernelInstance{<:CubicSpline}, q::T) where {T}
     (; αD) = kernel
-    return αD * (((1 - (3/2)*q^2 + (3/4)*q^3) * (0 <= q <= 1)) + ((1/4)*(2 - q)^3 * (1 < q <= 2)))
+    if q <= 1
+        return αD * (1 - (3/2) * q^2 + (3/4) * q^3)
+    elseif q <= 2
+        return αD * (1/4) * (2 - q)^3
+    else
+        return zero(T)
+    end
 end
 
 @inline function ∇Wᵢⱼ(kernel::SPHKernelInstance{<:CubicSpline}, q::T, xᵢⱼ) where {T}


### PR DESCRIPTION
## Summary
- avoid boolean multiplication in cubic spline kernel by using conditional branches

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test()'` *(fails: Package SPHExample errored during testing)*

------
https://chatgpt.com/codex/tasks/task_b_68b4ca732ff0832d800877c76e3a73a4