### PR TITLE
Preallocate CellDict in UpdateNeighbors!

### DIFF
--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -89,6 +89,7 @@ using Bumper
         ParticleRanges[IndexCounter]  = 1
         UniqueCells[IndexCounter]     = Cells[1]
         empty!(CellDict)
+        sizehint!(CellDict, length(Particles))  # preallocate to minimize rehashing
         CellDict[Cells[1]] = IndexCounter
 
         @inbounds @simd ivdep for i in eachindex(Cells)[2:end]


### PR DESCRIPTION
## Summary
- preallocate neighbor dictionary in `UpdateNeighbors!` to avoid rehashing

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test()'`


------
https://chatgpt.com/codex/tasks/task_b_68b4ca4fbabc832d85c16db16f922486