### PR TITLE
Use atomic once updates

### DIFF
--- a/src/PreProcess.jl
+++ b/src/PreProcess.jl
@@ -1,6 +1,6 @@
 module PreProcess
 
-export LoadBoundaryNormals, AllocateDataStructures, AllocateSupportDataStructures, AllocateThreadedArrays
+export LoadBoundaryNormals, AllocateDataStructures, AllocateSupportDataStructures, AllocateAtomicState
 
 using CSV
 using StaticArrays
@@ -137,25 +137,20 @@ function AllocateSupportDataStructures(Position)
     return dρdtI, Velocityₙ⁺, Positionₙ⁺, ρₙ⁺, ∇Cᵢ, ∇◌rᵢ
 end
 
-function AllocateThreadedArrays(SimMetaData, SimParticles, dρdtI, ∇Cᵢ, ∇◌rᵢ)
+function AllocateAtomicState(SimMetaData, n)
 
-    n = length(dρdtI)
     locks = [ReentrantLock() for _ in 1:n]
     step = Ref{Int}(0)
 
     nt = (
         locks = locks,
         step = step,
-        dρdtI = dρdtI,
-        Acceleration = SimParticles.Acceleration,
         dρdtI_touched = zeros(Int, n),
         Acceleration_touched = zeros(Int, n),
     )
 
     if SimMetaData.FlagOutputKernelValues
         nt = merge(nt, (
-            Kernel = SimParticles.Kernel,
-            KernelGradient = SimParticles.KernelGradient,
             Kernel_touched = zeros(Int, n),
             KernelGradient_touched = zeros(Int, n),
         ))
@@ -163,8 +158,6 @@ function AllocateThreadedArrays(SimMetaData, SimParticles, dρdtI, ∇Cᵢ, ∇�
 
     if SimMetaData.FlagShifting
         nt = merge(nt, (
-            ∇Cᵢ = ∇Cᵢ,
-            ∇◌rᵢ = ∇◌rᵢ,
             ∇Cᵢ_touched = zeros(Int, n),
             ∇◌rᵢ_touched = zeros(Int, n),
         ))

--- a/src/PreProcess.jl
+++ b/src/PreProcess.jl
@@ -137,38 +137,40 @@ function AllocateSupportDataStructures(Position)
     return dρdtI, Velocityₙ⁺, Positionₙ⁺, ρₙ⁺, ∇Cᵢ, ∇◌rᵢ
 end
 
-function AllocateThreadedArrays(SimMetaData, SimParticles, dρdtI, ∇Cᵢ, ∇◌rᵢ   ; n_copy = Base.Threads.nthreads())
-    
-        
-    dρdtIThreaded        = [copy(dρdtI) for _ in 1:n_copy]
-    AccelerationThreaded = [copy(SimParticles.KernelGradient) for _ in 1:n_copy]
+function AllocateThreadedArrays(SimMetaData, SimParticles, dρdtI, ∇Cᵢ, ∇◌rᵢ)
+
+    n = length(dρdtI)
+    locks = [ReentrantLock() for _ in 1:n]
+    step = Ref{Int}(0)
 
     nt = (
-        dρdtIThreaded = dρdtIThreaded,
-        AccelerationThreaded = AccelerationThreaded,
+        locks = locks,
+        step = step,
+        dρdtI = dρdtI,
+        Acceleration = SimParticles.Acceleration,
+        dρdtI_touched = zeros(Int, n),
+        Acceleration_touched = zeros(Int, n),
     )
 
     if SimMetaData.FlagOutputKernelValues
-        KernelThreaded         = [copy(SimParticles.Kernel) for _ in 1:n_copy]
-        KernelGradientThreaded = [copy(SimParticles.KernelGradient) for _ in 1:n_copy]
         nt = merge(nt, (
-            KernelThreaded = KernelThreaded,
-            KernelGradientThreaded = KernelGradientThreaded,
+            Kernel = SimParticles.Kernel,
+            KernelGradient = SimParticles.KernelGradient,
+            Kernel_touched = zeros(Int, n),
+            KernelGradient_touched = zeros(Int, n),
         ))
     end
 
     if SimMetaData.FlagShifting
-        ∇CᵢThreaded  = [copy(∇Cᵢ) for _ in 1:n_copy]
-        ∇◌rᵢThreaded = [copy(∇◌rᵢ) for _ in 1:n_copy]
         nt = merge(nt, (
-            ∇CᵢThreaded  = ∇CᵢThreaded,
-            ∇◌rᵢThreaded = ∇◌rᵢThreaded,
+            ∇Cᵢ = ∇Cᵢ,
+            ∇◌rᵢ = ∇◌rᵢ,
+            ∇Cᵢ_touched = zeros(Int, n),
+            ∇◌rᵢ_touched = zeros(Int, n),
         ))
     end
 
-    SimThreadedArrays = StructArray(nt)
-
-    return SimThreadedArrays
+    return nt
 end
 
 function LoadBoundaryNormals(::Val{D}, ::Type{T}, path_mdbc) where {D, T}

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -89,6 +89,7 @@ using Bumper
         ParticleRanges[IndexCounter]  = 1
         UniqueCells[IndexCounter]     = Cells[1]
         empty!(CellDict)
+        sizehint!(CellDict, length(Particles))  # preallocate to minimize rehashing
         CellDict[Cells[1]] = IndexCounter
 
         @inbounds @simd ivdep for i in eachindex(Cells)[2:end]

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -18,7 +18,7 @@ using ..SPHKernels
 using ..SPHViscosityModels
 using ..SPHDensityDiffusionModels
 
-import StructArrays: StructArray, foreachfield
+import StructArrays: StructArray
 import LinearAlgebra: dot, norm, diagm, diag, cond, det
 import FastPow: @fastpow
 import ProgressMeter: next!, finish!
@@ -135,7 +135,7 @@ using Bumper
                             ComputeInteractions!(SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                                                 SimConstants, SimParticles, SimThreadedArrays,
                                                 Position, Density, Pressure, Velocity,
-                                                i, j, MotionLimiter, Threads.threadid())
+                                                i, j, MotionLimiter)
                         end
 
                         # (2) Interactions between this cell and each neighboring cell in the stencil
@@ -148,7 +148,7 @@ using Bumper
                                 ComputeInteractions!(SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                                                     SimConstants, SimParticles, SimThreadedArrays,
                                                     Position, Density, Pressure, Velocity,
-                                                    i, j, MotionLimiter, Threads.threadid())
+                                                    i, j, MotionLimiter)
                             end
                         end
                     end
@@ -208,25 +208,23 @@ using Bumper
         return nothing
     end
 
-    Base.@propagate_inbounds function ComputeInteractions!(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel, SimMetaData, SimConstants, SimParticles, SimThreadedArrays, Position, Density, Pressure, Velocity, i, j, MotionLimiter, ichunk) where {SDD<:SPHDensityDiffusion, SV<:SPHViscosity}
+    Base.@propagate_inbounds function ComputeInteractions!(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel, SimMetaData, SimConstants, SimParticles, SimThreadedArrays, Position, Density, Pressure, Velocity, i, j, MotionLimiter) where {SDD<:SPHDensityDiffusion, SV<:SPHViscosity}
         (; FlagOutputKernelValues) = SimMetaData
         (; ρ₀, m₀, α, γ, g, c₀, δᵩ, Cb, Cb⁻¹, ν₀, dx, SmagorinskyConstant, BlinConstant) = SimConstants
 
         (; h⁻¹, h, η², H², αD) = SimKernel
 
         xᵢⱼ  = Position[i] - Position[j]
-        xᵢⱼ² = dot(xᵢⱼ,xᵢⱼ)              
+        xᵢⱼ² = dot(xᵢⱼ,xᵢⱼ)
         if  xᵢⱼ² <= H²
-            #https://discourse.julialang.org/t/sqrt-abs-x-is-even-faster-than-sqrt/58154/2
             dᵢⱼ  = sqrt(abs(xᵢⱼ²))
 
-            # clamp seems faster than min, no util
-            q         = clamp(dᵢⱼ * h⁻¹, 0.0, 2.0) #min(dᵢⱼ * h⁻¹, 2.0) - 8% util no DDT
+            q         = clamp(dᵢⱼ * h⁻¹, 0.0, 2.0)
             ∇ᵢWᵢⱼ     = @fastpow ∇Wᵢⱼ(SimKernel, q, xᵢⱼ)
-            
+
             ρᵢ        = Density[i]
             ρⱼ        = Density[j]
-        
+
             vᵢ        = Velocity[i]
             vⱼ        = Velocity[j]
             vᵢⱼ       = vᵢ - vⱼ
@@ -236,9 +234,9 @@ using Bumper
 
             Dᵢ, Dⱼ = compute_density_diffusion(SimDensityDiffusion, SimKernel, SimConstants, SimParticles, xᵢⱼ, ∇ᵢWᵢⱼ, xᵢⱼ², i, j, MotionLimiter)
 
-            SimThreadedArrays.dρdtIThreaded[ichunk][i] += dρdt⁺ + Dᵢ
-            SimThreadedArrays.dρdtIThreaded[ichunk][j] += dρdt⁻ + Dⱼ
-
+            step = SimThreadedArrays.step[]
+            atomiconce_add!(SimThreadedArrays.dρdtI, SimThreadedArrays.dρdtI_touched, SimThreadedArrays.locks, i, dρdt⁺ + Dᵢ, step)
+            atomiconce_add!(SimThreadedArrays.dρdtI, SimThreadedArrays.dρdtI_touched, SimThreadedArrays.locks, j, dρdt⁻ + Dⱼ, step)
 
             Pᵢ      =  Pressure[i]
             Pⱼ      =  Pressure[j]
@@ -249,29 +247,26 @@ using Bumper
             visc_term, _ = compute_viscosity(SimViscosity, SimKernel, SimConstants, SimParticles, xᵢⱼ, vᵢⱼ, ∇ᵢWᵢⱼ, xᵢⱼ², i, j)
 
             uₘ = dvdt⁺ + visc_term
-            SimThreadedArrays.AccelerationThreaded[ichunk][i] += uₘ
-            SimThreadedArrays.AccelerationThreaded[ichunk][j] -= uₘ 
+            atomiconce_add!(SimThreadedArrays.Acceleration, SimThreadedArrays.Acceleration_touched, SimThreadedArrays.locks, i, uₘ, step)
+            atomiconce_add!(SimThreadedArrays.Acceleration, SimThreadedArrays.Acceleration_touched, SimThreadedArrays.locks, j, -uₘ, step)
 
-            
             if FlagOutputKernelValues
                 Wᵢⱼ  = @fastpow SPHKernels.Wᵢⱼ(SimKernel, q)
-                SimThreadedArrays.KernelThreaded[ichunk][i]         += Wᵢⱼ
-                SimThreadedArrays.KernelThreaded[ichunk][j]         += Wᵢⱼ
-                SimThreadedArrays.KernelGradientThreaded[ichunk][i] +=  ∇ᵢWᵢⱼ
-                SimThreadedArrays.KernelGradientThreaded[ichunk][j] += -∇ᵢWᵢⱼ
+                atomiconce_add!(SimThreadedArrays.Kernel, SimThreadedArrays.Kernel_touched, SimThreadedArrays.locks, i, Wᵢⱼ, step)
+                atomiconce_add!(SimThreadedArrays.Kernel, SimThreadedArrays.Kernel_touched, SimThreadedArrays.locks, j, Wᵢⱼ, step)
+                atomiconce_add!(SimThreadedArrays.KernelGradient, SimThreadedArrays.KernelGradient_touched, SimThreadedArrays.locks, i, ∇ᵢWᵢⱼ, step)
+                atomiconce_add!(SimThreadedArrays.KernelGradient, SimThreadedArrays.KernelGradient_touched, SimThreadedArrays.locks, j, -∇ᵢWᵢⱼ, step)
             end
 
             if SimMetaData.FlagShifting
-                
+
                 MLcond = MotionLimiter[i] * MotionLimiter[j]
 
-                SimThreadedArrays.∇CᵢThreaded[ichunk][i]   += (m₀/ρᵢ) *  ∇ᵢWᵢⱼ
-                SimThreadedArrays.∇CᵢThreaded[ichunk][j]   += (m₀/ρⱼ) * -∇ᵢWᵢⱼ
-        
-                # Switch signs compared to DSPH, else free surface detection does not make sense
-                # Agrees, https://arxiv.org/abs/2110.10076, it should have been r_ji
-                SimThreadedArrays.∇◌rᵢThreaded[ichunk][i]  += (m₀/ρⱼ) * dot(-xᵢⱼ , ∇ᵢWᵢⱼ)  * MLcond
-                SimThreadedArrays.∇◌rᵢThreaded[ichunk][j]  += (m₀/ρᵢ) * dot( xᵢⱼ ,-∇ᵢWᵢⱼ)  * MLcond
+                atomiconce_add!(SimThreadedArrays.∇Cᵢ, SimThreadedArrays.∇Cᵢ_touched, SimThreadedArrays.locks, i, (m₀/ρᵢ) *  ∇ᵢWᵢⱼ, step)
+                atomiconce_add!(SimThreadedArrays.∇Cᵢ, SimThreadedArrays.∇Cᵢ_touched, SimThreadedArrays.locks, j, (m₀/ρⱼ) * -∇ᵢWᵢⱼ, step)
+
+                atomiconce_add!(SimThreadedArrays.∇◌rᵢ, SimThreadedArrays.∇◌rᵢ_touched, SimThreadedArrays.locks, i, (m₀/ρⱼ) * dot(-xᵢⱼ , ∇ᵢWᵢⱼ)  * MLcond, step)
+                atomiconce_add!(SimThreadedArrays.∇◌rᵢ, SimThreadedArrays.∇◌rᵢ_touched, SimThreadedArrays.locks, j, (m₀/ρᵢ) * dot( xᵢⱼ ,-∇ᵢWᵢⱼ)  * MLcond, step)
             end
         end
 
@@ -326,64 +321,21 @@ using Bumper
         return bΔ, AΔ
     end
 
-    function reduce_sum!(target_array, arrays)
-        n = length(target_array)
-        num_threads = nthreads()
-        chunk_size = ceil(Int, n / num_threads)
-        @inbounds @threads for t in 1:num_threads
-            local start_idx = 1 + (t-1) * chunk_size
-            local end_idx = min(t * chunk_size, n)
-            for j in eachindex(arrays)
-                local array = arrays[j]  # Access array only once per thread
-                @simd ivdep for i in start_idx:end_idx
-                    @inbounds target_array[i] += array[i]
-                end
-            end
+    @inline function atomiconce_add!(arr, touched, locks, idx, val, step)
+        l = locks[idx]
+        lock(l)
+        if touched[idx] != step
+            arr[idx] = val
+            touched[idx] = step
+        else
+            arr[idx] += val
         end
-    end
-
-    function ResetStep!(SimMetaData, SimThreadedArrays, dρdtI, Acceleration, Kernel, KernelGradient, ∇Cᵢ, ∇◌rᵢ)
-        # Threaded zeroing for main arrays
-        @threads for arr in (dρdtI, Acceleration)
-            fill!(arr, zero(eltype(arr)))
-        end
-
-        if SimMetaData.FlagOutputKernelValues
-            @threads for arr in (Kernel, KernelGradient)
-                fill!(arr, zero(eltype(arr)))
-            end
-        end
-
-        if SimMetaData.FlagShifting
-            @threads for arr in (∇Cᵢ, ∇◌rᵢ)
-                fill!(arr, zero(eltype(arr)))
-            end
-        end
-
-        # Threaded zeroing for fields in SimThreadedArrays
-        foreachfield(f -> begin
-            Threads.@threads for v in f
-                fill!(v, zero(eltype(v)))
-            end
-        end, SimThreadedArrays)
-
+        unlock(l)
         return nothing
     end
 
-    function ReductionStep!(SimMetaData, SimThreadedArrays, dρdtI, Acceleration, Kernel, KernelGradient, ∇Cᵢ, ∇◌rᵢ)
-        reduce_sum!(dρdtI, SimThreadedArrays.dρdtIThreaded)
-        reduce_sum!(Acceleration, SimThreadedArrays.AccelerationThreaded)
-  
-        if SimMetaData.FlagOutputKernelValues
-            reduce_sum!(Kernel, SimThreadedArrays.KernelThreaded)
-            reduce_sum!(KernelGradient, SimThreadedArrays.KernelGradientThreaded)
-        end
-
-        if SimMetaData.FlagShifting
-            reduce_sum!(∇Cᵢ, SimThreadedArrays.∇CᵢThreaded)
-            reduce_sum!(∇◌rᵢ, SimThreadedArrays.∇◌rᵢThreaded)
-        end
-    
+    function ResetStep!(SimThreadedArrays)
+        SimThreadedArrays.step[] += 1
         return nothing
     end
     
@@ -583,7 +535,7 @@ using Bumper
             
                 if !SimMetaData.FlagSingleStepTimeStepping
                     ###=== First step of resetting arrays
-                    @timeit SimMetaData.HourGlass "ResetArrays"                          ResetStep!(SimMetaData, SimThreadedArrays, dρdtI, Acceleration, Kernel, KernelGradient, ∇Cᵢ, ∇◌rᵢ)
+                    @timeit SimMetaData.HourGlass "ResetArrays"                          ResetStep!(SimThreadedArrays)
                     ###===
                 
                     @timeit SimMetaData.HourGlass "03 Pressure"                          Pressure!(SimParticles.Pressure,SimParticles.Density,SimConstants)
@@ -595,7 +547,6 @@ using Bumper
                     end
 
                     @timeit SimMetaData.HourGlass "04 First NeighborLoop"                NeighborLoop!(SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData, SimConstants, SimParticles, SimThreadedArrays, ParticleRanges, CellDict, Stencil, Position, Density, Pressure, Velocity, MotionLimiter, UniqueCellsView)
-                    @timeit SimMetaData.HourGlass "Reduction"                            ReductionStep!(SimMetaData, SimThreadedArrays, dρdtI, Acceleration, Kernel, KernelGradient, ∇Cᵢ, ∇◌rᵢ)
                 end
 
 
@@ -605,14 +556,13 @@ using Bumper
                 @timeit SimMetaData.HourGlass "06 Half LimitDensityAtBoundary"           LimitDensityAtBoundary!(ρₙ⁺, SimConstants.ρ₀, MotionLimiter)
             
                 ###=== Second step of resetting arrays
-                @timeit SimMetaData.HourGlass "ResetArrays"                              ResetStep!(SimMetaData, SimThreadedArrays, dρdtI, Acceleration, Kernel, KernelGradient, ∇Cᵢ, ∇◌rᵢ)
+                @timeit SimMetaData.HourGlass "ResetArrays"                              ResetStep!(SimThreadedArrays)
                 ###===
 
                 @timeit SimMetaData.HourGlass "Motion"                                   ProgressMotion(Position, Velocity, ParticleType, ParticleMarker, dt₂, MotionDefinition, SimMetaData)
             
                 @timeit SimMetaData.HourGlass "03 Pressure"                              Pressure!(SimParticles.Pressure, ρₙ⁺,SimConstants)
                 @timeit SimMetaData.HourGlass "08 Second NeighborLoop"                   NeighborLoop!(SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData, SimConstants, SimParticles, SimThreadedArrays, ParticleRanges, CellDict, Stencil, Positionₙ⁺, ρₙ⁺, Pressure, Velocityₙ⁺, MotionLimiter, UniqueCellsView)
-                @timeit SimMetaData.HourGlass "Reduction"                                ReductionStep!(SimMetaData, SimThreadedArrays, dρdtI, Acceleration, Kernel, KernelGradient, ∇Cᵢ, ∇◌rᵢ)
 
             
                 @timeit SimMetaData.HourGlass "09 Final LimitDensityAtBoundary"          LimitDensityAtBoundary!(Density, SimConstants.ρ₀, MotionLimiter)

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -110,9 +110,9 @@ using Bumper
 ###=== Function to process each cell and its neighbors
     function NeighborLoop!(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
                            SimMetaData, SimConstants, SimParticles,
-                           SimThreadedArrays, ParticleRanges, CellDict, Stencil,
-                           Position, Density, Pressure, Velocity, MotionLimiter,
-                           UniqueCellsView) where {SDD<:SPHDensityDiffusion, SV<:SPHViscosity}
+                           SimAtomics, ParticleRanges, CellDict, Stencil,
+                           Position, Density, Pressure, Velocity, dρdtI, ∇Cᵢ, ∇◌rᵢ,
+                           MotionLimiter, UniqueCellsView) where {SDD<:SPHDensityDiffusion, SV<:SPHViscosity}
 
         # ceil(length(CellDict)/nthreads()) then bump to even:
         base = (length(CellDict) + nthreads() - 1) ÷ nthreads()
@@ -133,8 +133,8 @@ using Bumper
                         # (1) Interactions among particles within the same cell `iter`
                         @inbounds for i = StartIndex:EndIndex, j = (i+1):EndIndex
                             ComputeInteractions!(SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
-                                                SimConstants, SimParticles, SimThreadedArrays,
-                                                Position, Density, Pressure, Velocity,
+                                                SimConstants, SimParticles, SimAtomics,
+                                                Position, Density, Pressure, Velocity, dρdtI, ∇Cᵢ, ∇◌rᵢ,
                                                 i, j, MotionLimiter)
                         end
 
@@ -146,8 +146,8 @@ using Bumper
                             EndIndex_    = ParticleRanges[NeighborIdx + 1] - 1
                             for i = StartIndex:EndIndex, j = StartIndex_:EndIndex_
                                 ComputeInteractions!(SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
-                                                    SimConstants, SimParticles, SimThreadedArrays,
-                                                    Position, Density, Pressure, Velocity,
+                                                    SimConstants, SimParticles, SimAtomics,
+                                                    Position, Density, Pressure, Velocity, dρdtI, ∇Cᵢ, ∇◌rᵢ,
                                                     i, j, MotionLimiter)
                             end
                         end
@@ -208,7 +208,7 @@ using Bumper
         return nothing
     end
 
-    Base.@propagate_inbounds function ComputeInteractions!(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel, SimMetaData, SimConstants, SimParticles, SimThreadedArrays, Position, Density, Pressure, Velocity, i, j, MotionLimiter) where {SDD<:SPHDensityDiffusion, SV<:SPHViscosity}
+    Base.@propagate_inbounds function ComputeInteractions!(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel, SimMetaData, SimConstants, SimParticles, SimAtomics, Position, Density, Pressure, Velocity, dρdtI, ∇Cᵢ, ∇◌rᵢ, i, j, MotionLimiter) where {SDD<:SPHDensityDiffusion, SV<:SPHViscosity}
         (; FlagOutputKernelValues) = SimMetaData
         (; ρ₀, m₀, α, γ, g, c₀, δᵩ, Cb, Cb⁻¹, ν₀, dx, SmagorinskyConstant, BlinConstant) = SimConstants
 
@@ -234,9 +234,9 @@ using Bumper
 
             Dᵢ, Dⱼ = compute_density_diffusion(SimDensityDiffusion, SimKernel, SimConstants, SimParticles, xᵢⱼ, ∇ᵢWᵢⱼ, xᵢⱼ², i, j, MotionLimiter)
 
-            step = SimThreadedArrays.step[]
-            atomiconce_add!(SimThreadedArrays.dρdtI, SimThreadedArrays.dρdtI_touched, SimThreadedArrays.locks, i, dρdt⁺ + Dᵢ, step)
-            atomiconce_add!(SimThreadedArrays.dρdtI, SimThreadedArrays.dρdtI_touched, SimThreadedArrays.locks, j, dρdt⁻ + Dⱼ, step)
+            step = SimAtomics.step[]
+            atomiconce_add!(dρdtI, SimAtomics.dρdtI_touched, SimAtomics.locks, i, dρdt⁺ + Dᵢ, step)
+            atomiconce_add!(dρdtI, SimAtomics.dρdtI_touched, SimAtomics.locks, j, dρdt⁻ + Dⱼ, step)
 
             Pᵢ      =  Pressure[i]
             Pⱼ      =  Pressure[j]
@@ -247,26 +247,26 @@ using Bumper
             visc_term, _ = compute_viscosity(SimViscosity, SimKernel, SimConstants, SimParticles, xᵢⱼ, vᵢⱼ, ∇ᵢWᵢⱼ, xᵢⱼ², i, j)
 
             uₘ = dvdt⁺ + visc_term
-            atomiconce_add!(SimThreadedArrays.Acceleration, SimThreadedArrays.Acceleration_touched, SimThreadedArrays.locks, i, uₘ, step)
-            atomiconce_add!(SimThreadedArrays.Acceleration, SimThreadedArrays.Acceleration_touched, SimThreadedArrays.locks, j, -uₘ, step)
+            atomiconce_add!(SimParticles.Acceleration, SimAtomics.Acceleration_touched, SimAtomics.locks, i, uₘ, step)
+            atomiconce_add!(SimParticles.Acceleration, SimAtomics.Acceleration_touched, SimAtomics.locks, j, -uₘ, step)
 
             if FlagOutputKernelValues
                 Wᵢⱼ  = @fastpow SPHKernels.Wᵢⱼ(SimKernel, q)
-                atomiconce_add!(SimThreadedArrays.Kernel, SimThreadedArrays.Kernel_touched, SimThreadedArrays.locks, i, Wᵢⱼ, step)
-                atomiconce_add!(SimThreadedArrays.Kernel, SimThreadedArrays.Kernel_touched, SimThreadedArrays.locks, j, Wᵢⱼ, step)
-                atomiconce_add!(SimThreadedArrays.KernelGradient, SimThreadedArrays.KernelGradient_touched, SimThreadedArrays.locks, i, ∇ᵢWᵢⱼ, step)
-                atomiconce_add!(SimThreadedArrays.KernelGradient, SimThreadedArrays.KernelGradient_touched, SimThreadedArrays.locks, j, -∇ᵢWᵢⱼ, step)
+                atomiconce_add!(SimParticles.Kernel, SimAtomics.Kernel_touched, SimAtomics.locks, i, Wᵢⱼ, step)
+                atomiconce_add!(SimParticles.Kernel, SimAtomics.Kernel_touched, SimAtomics.locks, j, Wᵢⱼ, step)
+                atomiconce_add!(SimParticles.KernelGradient, SimAtomics.KernelGradient_touched, SimAtomics.locks, i, ∇ᵢWᵢⱼ, step)
+                atomiconce_add!(SimParticles.KernelGradient, SimAtomics.KernelGradient_touched, SimAtomics.locks, j, -∇ᵢWᵢⱼ, step)
             end
 
             if SimMetaData.FlagShifting
 
                 MLcond = MotionLimiter[i] * MotionLimiter[j]
 
-                atomiconce_add!(SimThreadedArrays.∇Cᵢ, SimThreadedArrays.∇Cᵢ_touched, SimThreadedArrays.locks, i, (m₀/ρᵢ) *  ∇ᵢWᵢⱼ, step)
-                atomiconce_add!(SimThreadedArrays.∇Cᵢ, SimThreadedArrays.∇Cᵢ_touched, SimThreadedArrays.locks, j, (m₀/ρⱼ) * -∇ᵢWᵢⱼ, step)
+                atomiconce_add!(∇Cᵢ, SimAtomics.∇Cᵢ_touched, SimAtomics.locks, i, (m₀/ρᵢ) *  ∇ᵢWᵢⱼ, step)
+                atomiconce_add!(∇Cᵢ, SimAtomics.∇Cᵢ_touched, SimAtomics.locks, j, (m₀/ρⱼ) * -∇ᵢWᵢⱼ, step)
 
-                atomiconce_add!(SimThreadedArrays.∇◌rᵢ, SimThreadedArrays.∇◌rᵢ_touched, SimThreadedArrays.locks, i, (m₀/ρⱼ) * dot(-xᵢⱼ , ∇ᵢWᵢⱼ)  * MLcond, step)
-                atomiconce_add!(SimThreadedArrays.∇◌rᵢ, SimThreadedArrays.∇◌rᵢ_touched, SimThreadedArrays.locks, j, (m₀/ρᵢ) * dot( xᵢⱼ ,-∇ᵢWᵢⱼ)  * MLcond, step)
+                atomiconce_add!(∇◌rᵢ, SimAtomics.∇◌rᵢ_touched, SimAtomics.locks, i, (m₀/ρⱼ) * dot(-xᵢⱼ , ∇ᵢWᵢⱼ)  * MLcond, step)
+                atomiconce_add!(∇◌rᵢ, SimAtomics.∇◌rᵢ_touched, SimAtomics.locks, j, (m₀/ρᵢ) * dot( xᵢⱼ ,-∇ᵢWᵢⱼ)  * MLcond, step)
             end
         end
 
@@ -334,8 +334,8 @@ using Bumper
         return nothing
     end
 
-    function ResetStep!(SimThreadedArrays)
-        SimThreadedArrays.step[] += 1
+    function ResetStep!(SimAtomics)
+        SimAtomics.step[] += 1
         return nothing
     end
     
@@ -486,7 +486,7 @@ using Bumper
                                       SimMetaData::SimulationMetaData{Dimensions, FloatType},
                                       SimConstants, SimParticles, Stencil,
                                       ParticleRanges, UniqueCells, CellDict,
-                                      SortingScratchSpace, SimThreadedArrays,
+                                      SortingScratchSpace, SimAtomics,
                                       dρdtI, Velocityₙ⁺, Positionₙ⁺, ρₙ⁺,
                                       ∇Cᵢ, ∇◌rᵢ, MotionDefinition) where {Dimensions, FloatType, SDD<:SPHDensityDiffusion, SV<:SPHViscosity}
         Position       = SimParticles.Position
@@ -535,7 +535,7 @@ using Bumper
             
                 if !SimMetaData.FlagSingleStepTimeStepping
                     ###=== First step of resetting arrays
-                    @timeit SimMetaData.HourGlass "ResetArrays"                          ResetStep!(SimThreadedArrays)
+                    @timeit SimMetaData.HourGlass "ResetArrays"                          ResetStep!(SimAtomics)
                     ###===
                 
                     @timeit SimMetaData.HourGlass "03 Pressure"                          Pressure!(SimParticles.Pressure,SimParticles.Density,SimConstants)
@@ -546,7 +546,7 @@ using Bumper
                         @timeit SimMetaData.HourGlass "04b Apply MDBC before Half TimeStep"  ApplyMDBCCorrection(SimConstants, SimParticles, bᵧ, Aᵧ)
                     end
 
-                    @timeit SimMetaData.HourGlass "04 First NeighborLoop"                NeighborLoop!(SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData, SimConstants, SimParticles, SimThreadedArrays, ParticleRanges, CellDict, Stencil, Position, Density, Pressure, Velocity, MotionLimiter, UniqueCellsView)
+                    @timeit SimMetaData.HourGlass "04 First NeighborLoop"                NeighborLoop!(SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData, SimConstants, SimParticles, SimAtomics, ParticleRanges, CellDict, Stencil, Position, Density, Pressure, Velocity, dρdtI, ∇Cᵢ, ∇◌rᵢ, MotionLimiter, UniqueCellsView)
                 end
 
 
@@ -556,13 +556,13 @@ using Bumper
                 @timeit SimMetaData.HourGlass "06 Half LimitDensityAtBoundary"           LimitDensityAtBoundary!(ρₙ⁺, SimConstants.ρ₀, MotionLimiter)
             
                 ###=== Second step of resetting arrays
-                @timeit SimMetaData.HourGlass "ResetArrays"                              ResetStep!(SimThreadedArrays)
+                @timeit SimMetaData.HourGlass "ResetArrays"                              ResetStep!(SimAtomics)
                 ###===
 
                 @timeit SimMetaData.HourGlass "Motion"                                   ProgressMotion(Position, Velocity, ParticleType, ParticleMarker, dt₂, MotionDefinition, SimMetaData)
             
                 @timeit SimMetaData.HourGlass "03 Pressure"                              Pressure!(SimParticles.Pressure, ρₙ⁺,SimConstants)
-                @timeit SimMetaData.HourGlass "08 Second NeighborLoop"                   NeighborLoop!(SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData, SimConstants, SimParticles, SimThreadedArrays, ParticleRanges, CellDict, Stencil, Positionₙ⁺, ρₙ⁺, Pressure, Velocityₙ⁺, MotionLimiter, UniqueCellsView)
+                @timeit SimMetaData.HourGlass "08 Second NeighborLoop"                   NeighborLoop!(SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData, SimConstants, SimParticles, SimAtomics, ParticleRanges, CellDict, Stencil, Positionₙ⁺, ρₙ⁺, Pressure, Velocityₙ⁺, dρdtI, ∇Cᵢ, ∇◌rᵢ, MotionLimiter, UniqueCellsView)
 
             
                 @timeit SimMetaData.HourGlass "09 Final LimitDensityAtBoundary"          LimitDensityAtBoundary!(Density, SimConstants.ρ₀, MotionLimiter)
@@ -631,7 +631,7 @@ using Bumper
         NumberOfPoints = length(SimParticles)::Int
         Pressure!(SimParticles.Pressure,SimParticles.Density,SimConstants)
     
-        SimThreadedArrays = AllocateThreadedArrays(SimMetaData, SimParticles, dρdtI, ∇Cᵢ, ∇◌rᵢ)
+        SimAtomics = AllocateAtomicState(SimMetaData, length(dρdtI))
     
         # Produce sorting related variables
         ParticleRanges         = zeros(Int, NumberOfPoints + 1 + 1) # +1 for the last particle, +1 for dummy entry
@@ -681,7 +681,7 @@ using Bumper
 
         @inbounds while true
 
-            @timeit SimMetaData.HourGlass "00 SimulationLoop" SimulationLoop(SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData, SimConstants, SimParticles, Stencil, ParticleRanges, UniqueCells, CellDict, SortingScratchSpace, SimThreadedArrays, dρdtI, Velocityₙ⁺, Positionₙ⁺, ρₙ⁺, ∇Cᵢ, ∇◌rᵢ, MotionDefinition)
+            @timeit SimMetaData.HourGlass "00 SimulationLoop" SimulationLoop(SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData, SimConstants, SimParticles, Stencil, ParticleRanges, UniqueCells, CellDict, SortingScratchSpace, SimAtomics, dρdtI, Velocityₙ⁺, Positionₙ⁺, ρₙ⁺, ∇Cᵢ, ∇◌rᵢ, MotionDefinition)
             push!(TimeSteps, SimMetaData.CurrentTimeStep)
 
             if SimMetaData.FlagLog

--- a/src/SPHExample.jl
+++ b/src/SPHExample.jl
@@ -37,7 +37,7 @@ module SPHExample
     export ParticleType, Fixed, Fluid, Moving, Geometry, MotionDetails
 
     using .PreProcess
-    export AllocateDataStructures, AllocateSupportDataStructures, AllocateThreadedArrays, LoadBoundaryNormals
+    export AllocateDataStructures, AllocateSupportDataStructures, AllocateAtomicState, LoadBoundaryNormals
 
     using .ProduceHDFVTK
     export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure, AppendVTKHDFData, SaveCellGridVTKHDF, AppendVTKHDFGridData, SetupVTKOutput


### PR DESCRIPTION
## Summary
- replace thread-local reductions with atomic once accumulation
- drop array reset/reduction steps in favor of step counter

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test()'`


------
https://chatgpt.com/codex/tasks/task_b_68b59e7b9c50832da42346cb23cc30b0